### PR TITLE
service/rpc2: Fix panic in ListDynamicLibraries (#2586)

### DIFF
--- a/service/rpc2/server.go
+++ b/service/rpc2/server.go
@@ -838,7 +838,7 @@ func (s *RPCServer) ListDynamicLibraries(in ListDynamicLibrariesIn, out *ListDyn
 	imgs := s.debugger.ListDynamicLibraries()
 	out.List = make([]api.Image, 0, len(imgs))
 	for i := range imgs {
-		out.List[i] = api.ConvertImage(imgs[i])
+		out.List = append(out.List, api.ConvertImage(imgs[i]))
 	}
 	return nil
 }


### PR DESCRIPTION
The slice `out.List` is created with a length of 0 but a capacity of
`len(imgs)`. This causes the line below to panic as we try to index into
the `out.List` slice instead of append to it. This patch resolves the
issue by appending instead of indexing into the slice.

Co-authored-by: Derek Parker <deparker@redhat.com>